### PR TITLE
[LEVWEB-1378] Correct History snapshot

### DIFF
--- a/test/lev-report/__snapshots__/History.test.js.snap
+++ b/test/lev-report/__snapshots__/History.test.js.snap
@@ -537,7 +537,7 @@ Array [
 }
 
 <div
-    className="sc-oTNDV c0"
+    className="lev-top-nav__WideTopNavWrapper-sc-1xqrio7-1 c0"
   >
     <div
       className="c1 c2"


### PR DESCRIPTION
Shows the improved class name that comes with: `"babel-plugin-styled-components": "^1.10.0"`