### PR TITLE
Ignore unnecessary resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 node_modules/
 .floo*
+.idea/
 
 # any snapshot component previews
 **/__snapshots__/*.html

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,2 @@
 src/
-*.jsx
+.idea/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,8 @@
 src/
+test/
+./*.js
+./*.jsx
+./*.json
+.babelrc
 .idea/
+.floo*

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-src/
-test/
-./*.js
-./*.jsx
-./*.json
-.babelrc
-.idea/
-.floo*

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "React.js components for use in the LEV project",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "/dist",
+    "/README.md"
+  ],
   "scripts": {
     "test": "jest",
     "visualise": "VISUALISE=true npm test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-react-components",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "React.js components for use in the LEV project",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Don't commit IntelliJ clutter.
Don't bundle anything except the `dist/` folder and the `README.md` into the NPM release.